### PR TITLE
Update to Selenium 4.9.1 (#31)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false  # to use new infrastructure
 language: java
 addons:
-    firefox: "111.0.1"
+    firefox: "113.0.2"
 before_install:
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.32.2/geckodriver-v0.32.2-linux64.tar.gz
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz
   - mkdir geckodriver
-  - tar -xzf geckodriver-v0.32.2-linux64.tar.gz -C geckodriver
+  - tar -xzf geckodriver-v0.33.0-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
 install: "mvn -Dmaven.test.skip=true clean install --batch-mode"
 script: "mvn -Djava.awt.headless=true -Dmaven.test.redirectTestOutputToFile=true --fail-at-end --batch-mode org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-webdriver</artifactId>
-    <version>4.8.3.2</version>
+    <version>4.9.1.0</version>
     <packaging>jar</packaging>
 
     <name>WebDriver/Selenium</name>
@@ -34,7 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <selenium.version>4.8.3</selenium.version>
+        <selenium.version>4.9.1</selenium.version>
     </properties>
 
     <build>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>htmlunit-driver</artifactId>
-            <version>4.8.1.1</version>
+            <version>${selenium.version}</version>
         </dependency>
         <!-- begin need this libraries for HtmlUnitDriver -->
         <dependency>
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.2</version>
+            <version>2.15.2</version>
         </dependency>
         <dependency>
             <groupId>de.sciss</groupId>


### PR DESCRIPTION
* Upgrade of dependencies. Removal of deprecated Phantomjs.
Removal of deprecated code.
Addition of "SuppressWarnings" tags where needed. To de resolved at a later stage.

* Adding IE capabilities for RemoteWebDriver.

* Upgrade of function call.

* Addition of field in the UI to set the path to the Firefox Gecko driver.

* Wiki update.

* Addition of input field for msegde.exe

* Clean-ups and finalisations.

* Addition of IE11 in MsEdge for Remote execution.

* Integrating changes from Shinu on Aug 26, 2019.

* Merging of thefuckingcode changes from Apr 17, 2021.

* Setting of default value of path to msedge.exe

* Update of Chrome tests to JDK 17.

* Update of Firefox tests to JDK 17.

* Upgrade of HTMLUntit tests to JDK 17.

* Update of InternetExplorer tests to JDK 17.

* Update of RemoteDriver tests to JDK 17.

* Update of WebDriver tests to JDK 17.

* Formatting fixes.

* Formatting fixes 2.

* Formatting fixes #3.

* Addition of Geckodriver v0.31 for Firefox tests.

* Usage of GeckoDriver default service for unit tests instead of real Geckodriver.exe.

* Update to Selenium 4.5

* Ui fix.

* Addition of geckodriver to travis CI for the firefox tests

* Matching Continous Integration test conditions.

* Setting IE's Protected Mode to "off" to allow IE to start in all environments.

* Removaĺ of path to Edge as from IEDriver v4.5.0, the driver will automatically locate Edge on the system.

* Ui Refactor 1

* Update to Seleniuṁ 4.6.0

* UI Refactor

* Adding of new wiki page for direct browseŕ testing.

* Updating wiki pages for new UI.

* Tests update 1.

* Update of Chrome and IE tests.

* Pom update.

* Imporţclean-ups.

* Update of Readme.md.

* Fix of broken wiki links.

* Fix of broken link #2.

* Take #3

* Code format

* Code format #2

* Syntax highlight.

* Initial Browser URL now in UI and not hard coded.

* Test fixes.

* Upgrade to Selenium 4.7.2 and addition of driver for Edge.

* Update of tests.

* Removing "ignoring zoom levels" in IE as it is no longer required from Seleniuṁ 4.7.0.

* Upgrade to Selenium 4.8.0

* Proxy UI fix in Firefox && upgrade to Selenium 4.8.1.

* Upgrade to Selenium 4.8.3.

* Fixing of Help Link in Config drivers which was outdated.

* Removal of isBlank() call as it requires Java 11 and JMeter targets 8.

* Update to Selenium 4.9.1